### PR TITLE
Update hero, dark mode, ESLint, and content sections

### DIFF
--- a/src/components/static/TerminalHero.tsx
+++ b/src/components/static/TerminalHero.tsx
@@ -12,7 +12,7 @@ export function TerminalHero() {
             Software Engineer
           </span>
         </p>
-        <div className="flex space-x-5 md:space-x-7 justify-center md:justify-start items-center">
+        <div className="flex flex-wrap gap-x-5 md:gap-x-7 gap-y-2 md:gap-y-3 justify-center md:justify-start items-center">
           <a 
             href="https://zenn.dev/enumura" 
             target="_blank"
@@ -29,13 +29,21 @@ export function TerminalHero() {
           >
             Qiita
           </a>
-          <a 
-            href="https://github.com/enumura1" 
+          <a
+            href="https://github.com/enumura1"
             target="_blank"
             rel="noopener noreferrer"
             className="text-lg md:text-xl lg:text-3xl font-medium text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 transition-colors"
           >
             GitHub
+          </a>
+          <a
+            href="https://speakerdeck.com/enumura1"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-lg md:text-xl lg:text-3xl font-medium text-teal-300 dark:text-teal-400 hover:text-teal-400 dark:hover:text-teal-300 transition-colors"
+          >
+            SpeakerDeck
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- SpeakerDeck link added to hero section alongside Zenn, Qiita, GitHub
- Dark mode flash on page load fixed
- ESLint config updated for ESLint 9 compatibility
- Dark mode toggle fix for Tailwind CSS 4
- Content updates: About, Certifications, Timeline (show more/less), Projects, Blog sections revised

## Test plan
- [ ] Verify SpeakerDeck link appears correctly in hero section
- [ ] Confirm no dark mode flash on initial page load
- [ ] Check lint passes with `npm run lint`
- [ ] Verify build succeeds with `npm run build`
- [ ] Test theme toggle works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)