### PR TITLE
fix: move py-sql-cleaner to Projects OSS section

### DIFF
--- a/src/components/static/OSSContributions.tsx
+++ b/src/components/static/OSSContributions.tsx
@@ -1,59 +1,13 @@
 import Link from 'next/link'
-import { GitPullRequest, ExternalLink, Package } from 'lucide-react'
+import { GitPullRequest, ExternalLink } from 'lucide-react'
 
 export function OSSContributions() {
   return (
     <section className="py-20 px-4 max-w-4xl mx-auto" id="oss-contributions">
       <h2 className="text-4xl font-bold mb-8">🚀 Open Source Contributions</h2>
-      
-      {/* py-sql-cleaner */}
-      <div className="bg-gray-50 dark:bg-gray-800
-                    border border-gray-200 dark:border-gray-700 rounded-xl p-6 mb-4
-                    transition-all duration-300 hover:border-blue-200 dark:hover:border-blue-700 hover:shadow-md">
-        <div className="flex items-start gap-4">
-          <div className="flex-shrink-0">
-            <div className="w-12 h-12 bg-green-500/20 dark:bg-green-500/30 rounded-lg
-                          flex items-center justify-center">
-              <Package className="w-6 h-6 text-green-500" />
-            </div>
-          </div>
-
-          <div className="flex-1">
-            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-3">
-              py-sql-cleaner
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300 mb-4 leading-relaxed">
-              A Python tool for managing SQL embedded in Python source files.
-              Supports scanning, formatting, and extracting inline SQL queries,
-              with safe handling of dynamic templates like f-strings and Jinja.
-            </p>
-
-            <div className="flex items-center gap-4">
-              <a
-                href="https://github.com/enumura1/py-sql-cleaner"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-500 hover:text-blue-400 inline-flex items-center text-sm"
-              >
-                <span className="mr-1">GitHub</span>
-                <ExternalLink className="w-3 h-3" />
-              </a>
-              <a
-                href="https://enumura1.github.io/py-sql-cleaner/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-500 hover:text-blue-400 inline-flex items-center text-sm"
-              >
-                <span className="mr-1">Docs</span>
-                <ExternalLink className="w-3 h-3" />
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
 
       {/* メインCTAカード */}
-      <div className="bg-gray-50 dark:bg-gray-800 
+      <div className="bg-gray-50 dark:bg-gray-800
                     border border-gray-200 dark:border-gray-700 rounded-xl p-6
                     transition-all duration-300 hover:border-blue-200 dark:hover:border-blue-700 hover:shadow-md">
         <div className="flex items-start gap-4">

--- a/src/components/static/Projects.tsx
+++ b/src/components/static/Projects.tsx
@@ -30,6 +30,14 @@ const projects: Project[] = [
     type: "Hackathon"
   },
   {
+    title: "py-sql-cleaner",
+    description: "A Python tool for managing SQL embedded in Python source files. Supports scanning, formatting, and extracting inline SQL queries, with safe handling of dynamic templates like f-strings and Jinja.",
+    technologies: ["Python", "CLI", "PyPI package"],
+    link: "https://enumura1.github.io/py-sql-cleaner/",
+    github: "https://github.com/enumura1/py-sql-cleaner",
+    type: "OSS"
+  },
+  {
     title: "chatbot-flow-editor",
     description: "Visual chatbot flow editor with drag-and-drop interface. Design conversation paths, test flows in a live chat simulator, and export as JSON.",
     technologies: ["React", "TypeScript", "npm package"],


### PR DESCRIPTION
## Summary
- Move py-sql-cleaner to the correct location: Projects section under 🌐 OSS, at the top of the list
- Revert the mistaken addition to OSSContributions section (that section is for contributions to *other* projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)